### PR TITLE
Fix dollar side effects

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,8 +6,8 @@ describe('Multi currency money', () => {
   describe('multiplication', () => {
     it('should multiply $5 by 2 and get $10', () => {
       const five = new Dollar(5);
-      five.times(2);
-      expect(five.amount).toEqual(10);
+      const product = five.times(2);
+      expect(product.amount).toEqual(10);
     });
 
     it('should preserve the initial dollar amount when multiplying multiple times', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -9,5 +9,13 @@ describe('Multi currency money', () => {
       five.times(2);
       expect(five.amount).toEqual(10);
     });
+
+    it('should preserve the initial dollar amount when multiplying multiple times', () => {
+      const five = new Dollar(5);
+      five.times(2);
+      expect(five.amount).toEqual(10);
+      five.times(3);
+      expect(five.amount).toEqual(15);
+    });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -12,10 +12,10 @@ describe('Multi currency money', () => {
 
     it('should preserve the initial dollar amount when multiplying multiple times', () => {
       const five = new Dollar(5);
-      five.times(2);
-      expect(five.amount).toEqual(10);
-      five.times(3);
-      expect(five.amount).toEqual(15);
+      let product: Dollar = five.times(2);
+      expect(product.amount).toEqual(10);
+      product = five.times(3);
+      expect(product.amount).toEqual(15);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export default class Dollar {
     this.amount = amount;
   }
 
-  times(multiplier: number) {
-    this.amount *= multiplier;
+  times(multiplier: number): Dollar {
+    return new Dollar(this.amount * multiplier);
   }
 }


### PR DESCRIPTION
After committing a lot of sins in order to make the first test pass, we've introduce a subtle side effect: a dollar object can't be reliably multiplied many times, this happens because we're updating the `amount` instance variable, thus keeping the updated value as part of the current object. To solve this problem, a new `Dollar` object is now being returned as a result of `Dollar.times`.

Our current tasklist is:
- $5 + 10CHF = $10 if rate is 2:1 🎯
- ~$5 * 2 = $10~ ✅
- Make "amount" private
- ~Dollar side-effects?~ ✅
- Money rounding?