### PR TITLE
Implement equality for Dollar

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -18,4 +18,10 @@ describe('Multi currency money', () => {
       expect(product.amount).toEqual(15);
     });
   });
+
+  describe('equality', () => {
+    it('should consider an object representing $5 equals to another object representing $5', () => {
+      expect(new Dollar(5).equals(new Dollar(5))).toBe(true);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export default class Dollar {
     return new Dollar(this.amount * multiplier);
   }
 
-  equals(dollar: Dollar): boolean {
-    return true;
+  equals(dollar: Object): boolean {
+    return this.amount == (dollar as Dollar).amount;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,8 @@ export default class Dollar {
   times(multiplier: number): Dollar {
     return new Dollar(this.amount * multiplier);
   }
+
+  equals(dollar: Dollar): boolean {
+    return true;
+  }
 }


### PR DESCRIPTION
As our code is written in Typescript instead of Java, equality works a bit different. There's no `equals` method to override in subclasses, so what I've done here was actually implementing a `equals` method that receives a `dollar` object and casts it to a `Dollar`, finally comparing their amounts to see if there's a match. The function satisfies the equality logic approached by the book and brings, in the same way, two new concerns to our task list: checking equality when the input is null and when the input is another object. Our current tasklist is:

- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object