### PR TITLE
Make dollar amount private

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -7,15 +7,15 @@ describe('Multi currency money', () => {
     it('should multiply $5 by 2 and get $10', () => {
       const five = new Dollar(5);
       const product = five.times(2);
-      expect(product.amount).toEqual(10);
+      expect(product.equals(new Dollar(10))).toBe(true);
     });
 
     it('should preserve the initial dollar amount when multiplying multiple times', () => {
       const five = new Dollar(5);
       let product: Dollar = five.times(2);
-      expect(product.amount).toEqual(10);
+      expect(product.equals(new Dollar(10))).toBe(true);
       product = five.times(3);
-      expect(product.amount).toEqual(15);
+      expect(product.equals(new Dollar(15))).toBe(true);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export default class Dollar {
-  amount: number;
+  private amount: number;
 
   constructor(amount: number) {
     this.amount = amount;


### PR DESCRIPTION
Back to good OO design principles, we need to make `amount` private so the `Dollar` class is encapsulated. We accomplished that by simply updating the tests to use the recently added `.equal` method from the `Dollar` class.

Our current tasklist is:
- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object