### PR TITLE
Franc (CHF) multiplication

### DIFF
--- a/src/franc/index.spec.ts
+++ b/src/franc/index.spec.ts
@@ -1,0 +1,19 @@
+import Franc from '.';
+
+describe('Franc', () => {
+  describe('multiplication', () => {
+    it('should multiply $5 by 2 and get $10', () => {
+      const five = new Franc(5);
+      const product = five.times(2);
+      expect(product.equals(new Franc(10))).toBe(true);
+    });
+
+    it('should preserve the initial dollar amount when multiplying multiple times', () => {
+      const five = new Franc(5);
+      let product: Franc = five.times(2);
+      expect(product.equals(new Franc(10))).toBe(true);
+      product = five.times(3);
+      expect(product.equals(new Franc(15))).toBe(true);
+    });
+  });
+});

--- a/src/franc/index.ts
+++ b/src/franc/index.ts
@@ -1,0 +1,15 @@
+export default class Franc {
+  private amount: number;
+
+  constructor(amount: number) {
+    this.amount = amount;
+  }
+
+  times(multiplier: number): Franc {
+    return new Franc(this.amount * multiplier);
+  }
+
+  equals(dollar: Object): boolean {
+    return this.amount == (dollar as Franc).amount;
+  }
+}


### PR DESCRIPTION
A good step towards our main goal is having a different type of currency in the first place. This PR introduces a `Franc` class as a pure copy of the `Dollar` class, which brings the functionality we want, but also creates more concerns and increases the size of our list:

- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication
- Common `.equals`
- Common `.times`