### PR TITLE
Remove duplication between Dollar and Franc

### DIFF
--- a/src/dollar/index.ts
+++ b/src/dollar/index.ts
@@ -1,11 +1,8 @@
 import Money from '../money';
 
 export default class Dollar extends Money {
-  private amount: number;
-
   constructor(amount: number) {
-    super();
-    this.amount = amount;
+    super(amount);
   }
 
   times(multiplier: number): Dollar {

--- a/src/dollar/index.ts
+++ b/src/dollar/index.ts
@@ -9,7 +9,8 @@ export default class Dollar extends Money {
     return new Dollar(this.amount * multiplier);
   }
 
-  equals(dollar: Object): boolean {
-    return this.amount == (dollar as Dollar).amount;
+  equals(money: Object): boolean {
+    const other: Money = money as Money;
+    return this.amount == other.amount;
   }
 }

--- a/src/dollar/index.ts
+++ b/src/dollar/index.ts
@@ -8,9 +8,4 @@ export default class Dollar extends Money {
   times(multiplier: number): Dollar {
     return new Dollar(this.amount * multiplier);
   }
-
-  equals(money: Object): boolean {
-    const other: Money = money as Money;
-    return this.amount == other.amount;
-  }
 }

--- a/src/dollar/index.ts
+++ b/src/dollar/index.ts
@@ -1,7 +1,10 @@
-export default class Dollar {
+import Money from '../money';
+
+export default class Dollar extends Money {
   private amount: number;
 
   constructor(amount: number) {
+    super();
     this.amount = amount;
   }
 

--- a/src/franc/index.spec.ts
+++ b/src/franc/index.spec.ts
@@ -1,4 +1,5 @@
 import Franc from '.';
+import Dollar from '../dollar';
 
 describe('Franc', () => {
   describe('multiplication', () => {
@@ -14,6 +15,15 @@ describe('Franc', () => {
       expect(product.equals(new Franc(10))).toBe(true);
       product = five.times(3);
       expect(product.equals(new Franc(15))).toBe(true);
+    });
+  });
+
+  describe('equality', () => {
+    it('should consider an object representing $5 equals to another object representing $5', () => {
+      expect(new Franc(5).equals(new Franc(5))).toBe(true);
+      expect(new Franc(5).equals(new Franc(6))).toBe(false);
+      expect(new Dollar(5).equals(new Dollar(5))).toBe(true);
+      expect(new Dollar(5).equals(new Dollar(6))).toBe(false);
     });
   });
 });

--- a/src/franc/index.ts
+++ b/src/franc/index.ts
@@ -1,3 +1,5 @@
+import Money from "../money";
+
 export default class Franc {
   private amount: number;
 
@@ -9,7 +11,7 @@ export default class Franc {
     return new Franc(this.amount * multiplier);
   }
 
-  equals(dollar: Object): boolean {
-    return this.amount == (dollar as Franc).amount;
+  equals(object: Object): boolean {
+    return this.amount == (object as Money).amount;
   }
 }

--- a/src/franc/index.ts
+++ b/src/franc/index.ts
@@ -1,17 +1,11 @@
-import Money from "../money";
+import Money from '../money';
 
-export default class Franc {
-  private amount: number;
-
+export default class Franc extends Money {
   constructor(amount: number) {
-    this.amount = amount;
+    super(amount);
   }
 
   times(multiplier: number): Franc {
     return new Franc(this.amount * multiplier);
-  }
-
-  equals(object: Object): boolean {
-    return this.amount == (object as Money).amount;
   }
 }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,0 +1,1 @@
+export default class Money {}

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -8,4 +8,9 @@ export default class Money {
   get amount() {
     return this._amount;
   }
+
+  equals(obj: Object): boolean {
+    const money: Money = obj as Money;
+    return this.amount == money.amount;
+  }
 }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,7 +1,11 @@
 export default class Money {
-  protected amount: number;
+  private _amount: number;
 
   constructor(amount: number) {
-    this.amount = amount;
+    this._amount = amount;
+  }
+
+  get amount() {
+    return this._amount;
   }
 }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,1 +1,7 @@
-export default class Money {}
+export default class Money {
+  protected amount: number;
+
+  constructor(amount: number) {
+    this.amount = amount;
+  }
+}


### PR DESCRIPTION
We have two identical classes implemented: `Dollar` and `Franc`. This PR implements a common class for both of them: `Money`, which will start by holding the `amount` value and the `equals` method.

Our current task list is:

- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication
- Common `.equals` ✅
- Common `.times`
- Compare Francs with Dollars