### PR TITLE
Fix franc dollar comparison

### DIFF
--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -8,6 +8,7 @@ describe('Money', () => {
       expect(new Franc(5).equals(new Franc(6))).toBe(false);
       expect(new Dollar(5).equals(new Dollar(5))).toBe(true);
       expect(new Dollar(5).equals(new Dollar(6))).toBe(false);
+      expect(new Franc(5).equals(new Dollar(5))).toBe(false);
     });
   });
 });

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -11,6 +11,6 @@ export default class Money {
 
   equals(obj: Object): boolean {
     const money: Money = obj as Money;
-    return this.amount == money.amount;
+    return this.amount == money.amount && obj.constructor.name == this.constructor.name;
   }
 }


### PR DESCRIPTION
As we pulled up the `equals` method to the `Money`class and resorted all the comparisons against `Money` object, we've created an unintended side effect: now `Dollar` and `Franc` objects are considered equal. This PR fixes this problem by comparing `object.constructor.name` to the current `this.constructor.name`, which is basically using a (dirty) resource from the programming language to fix a domain problem, that's why we've added "Currency?" to the bottom of the task list:

- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication
- Common `.equals` ✅
- Common `.times`
- Compare Francs with Dollars ✅
- Currency?
