### PR TITLE
Implement currency

### DIFF
--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -47,7 +47,7 @@ describe('Franc', () => {
 
     it('should preserve the initial dollar amount when multiplying multiple times', () => {
       const five = Money.franc(5);
-      let product: Franc = five.times(2);
+      let product: Money = five.times(2);
       expect(product.equals(Money.franc(10))).toBe(true);
       product = five.times(3);
       expect(product.equals(Money.franc(15))).toBe(true);

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -10,6 +10,11 @@ describe('Money', () => {
       expect(Money.franc(5).equals(new Dollar(5))).toBe(false);
     });
   });
+
+  describe('currency', () => {
+    expect(Money.dollar(5).currency()).toEqual('USD');
+    expect(Money.franc(5).currency()).toEqual('CHF');
+  });
 });
 
 describe('Dollar', () => {

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -5,9 +5,9 @@ describe('Money', () => {
     it('should consider an object representing $5 equals to another object representing $5', () => {
       expect(Money.franc(5).equals(Money.franc(5))).toBe(true);
       expect(Money.franc(5).equals(Money.franc(6))).toBe(false);
-      expect(new Dollar(5).equals(new Dollar(5))).toBe(true);
-      expect(new Dollar(5).equals(new Dollar(6))).toBe(false);
-      expect(Money.franc(5).equals(new Dollar(5))).toBe(false);
+      expect(Money.dollar(5).equals(Money.dollar(5))).toBe(true);
+      expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
+      expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);
     });
   });
 

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -1,4 +1,4 @@
-import Money, { Dollar, Franc } from '../money';
+import Money, { Dollar } from '../money';
 
 describe('Money', () => {
   describe('equality', () => {
@@ -29,7 +29,7 @@ describe('Dollar', () => {
 
     it('should preserve the initial dollar amount when multiplying multiple times', () => {
       const five = Money.dollar(5);
-      let product: Dollar = five.times(2);
+      let product: Money = five.times(2);
       expect(product.equals(Money.dollar(10))).toBe(true);
       product = five.times(3);
       expect(product.equals(Money.dollar(15))).toBe(true);

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -1,4 +1,4 @@
-import Money, { Dollar } from '../money';
+import Money from '../money';
 
 describe('Money', () => {
   describe('equality', () => {
@@ -12,8 +12,8 @@ describe('Money', () => {
   });
 
   describe('currency', () => {
-    expect(Money.dollar(5).currency()).toEqual('USD');
-    expect(Money.franc(5).currency()).toEqual('CHF');
+    expect(Money.dollar(5).currency).toEqual('USD');
+    expect(Money.franc(5).currency).toEqual('CHF');
   });
 });
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,8 +1,10 @@
 abstract class Money {
   private _amount: number;
+  private _currency: string;
 
-  constructor(amount: number) {
+  constructor(amount: number, currency: string) {
     this._amount = amount;
+    this._currency = currency;
   }
 
   get amount() {
@@ -24,40 +26,20 @@ abstract class Money {
 
   abstract times(multiplier: number): Money;
 
-  abstract currency(): string;
+  currency(): string {
+    return this._currency;
+  }
 }
 
 export class Dollar extends Money {
-  private _currency: string;
-
-  constructor(amount: number, currency: string) {
-    super(amount);
-    this._currency = currency;
-  }
-
   times(multiplier: number): Money {
     return Money.dollar(this.amount * multiplier);
-  }
-
-  currency(): string {
-    return this._currency;
   }
 }
 
 export class Franc extends Money {
-  private _currency: string;
-
-  constructor(amount: number, currency: string) {
-    super(amount);
-    this._currency = currency;
-  }
-
   times(multiplier: number): Money {
     return Money.franc(this.amount * multiplier);
-  }
-
-  currency(): string {
-    return this._currency;
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -49,7 +49,7 @@ export class Franc extends Money {
 
   constructor(amount: number, currency: string) {
     super(amount);
-    this._currency = 'CHF';
+    this._currency = currency;
   }
 
   times(multiplier: number): Money {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -26,7 +26,7 @@ abstract class Money {
 
   abstract times(multiplier: number): Money;
 
-  currency(): string {
+  get currency(): string {
     return this._currency;
   }
 }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -19,7 +19,7 @@ abstract class Money {
   }
 
   static franc(amount: number): Money {
-    return new Franc(amount, '');
+    return new Franc(amount, 'CHF');
   }
 
   abstract times(multiplier: number): Money;

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -19,7 +19,7 @@ abstract class Money {
   }
 
   static franc(amount: number): Money {
-    return new Franc(amount);
+    return new Franc(amount, '');
   }
 
   abstract times(multiplier: number): Money;
@@ -47,13 +47,13 @@ export class Dollar extends Money {
 export class Franc extends Money {
   private _currency: string;
 
-  constructor(amount: number) {
+  constructor(amount: number, currency: string) {
     super(amount);
     this._currency = 'CHF';
   }
 
   times(multiplier: number): Franc {
-    return new Franc(this.amount * multiplier);
+    return new Franc(this.amount * multiplier, '');
   }
 
   currency(): string {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -52,8 +52,8 @@ export class Franc extends Money {
     this._currency = 'CHF';
   }
 
-  times(multiplier: number): Franc {
-    return new Franc(this.amount * multiplier, '');
+  times(multiplier: number): Money {
+    return Money.franc(this.amount * multiplier);
   }
 
   currency(): string {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -28,8 +28,11 @@ abstract class Money {
 }
 
 export class Dollar extends Money {
+  private _currency: string;
+
   constructor(amount: number) {
     super(amount);
+    this._currency = 'USD';
   }
 
   times(multiplier: number): Dollar {
@@ -37,7 +40,7 @@ export class Dollar extends Money {
   }
 
   currency(): string {
-    return 'USD';
+    return this._currency;
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -23,6 +23,8 @@ abstract class Money {
   }
 
   abstract times(multiplier: number): Money;
+
+  abstract currency(): string;
 }
 
 export class Dollar extends Money {
@@ -33,6 +35,10 @@ export class Dollar extends Money {
   times(multiplier: number): Dollar {
     return new Dollar(this.amount * multiplier);
   }
+
+  currency(): string {
+    return 'USD';
+  }
 }
 
 export class Franc extends Money {
@@ -42,6 +48,10 @@ export class Franc extends Money {
 
   times(multiplier: number): Franc {
     return new Franc(this.amount * multiplier);
+  }
+
+  currency(): string {
+    return 'CHF';
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -42,8 +42,11 @@ export class Dollar extends Money {
 }
 
 export class Franc extends Money {
+  private _currency: string;
+
   constructor(amount: number) {
     super(amount);
+    this._currency = 'CHF';
   }
 
   times(multiplier: number): Franc {
@@ -51,7 +54,7 @@ export class Franc extends Money {
   }
 
   currency(): string {
-    return 'CHF';
+    return this._currency;
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -15,7 +15,7 @@ abstract class Money {
   }
 
   static dollar(amount: number): Money {
-    return new Dollar(amount);
+    return new Dollar(amount, 'USD');
   }
 
   static franc(amount: number): Money {
@@ -30,13 +30,13 @@ abstract class Money {
 export class Dollar extends Money {
   private _currency: string;
 
-  constructor(amount: number) {
+  constructor(amount: number, currency: string) {
     super(amount);
-    this._currency = 'USD';
+    this._currency = currency;
   }
 
-  times(multiplier: number): Dollar {
-    return new Dollar(this.amount * multiplier);
+  times(multiplier: number): Money {
+    return Money.dollar(this.amount * multiplier);
   }
 
   currency(): string {


### PR DESCRIPTION
We are still on our way to removing `Dollar` and `Franc`, but to do so we first need to introduce the concept of currency so we can differentiate the two currencies. This PR implements this idea by exposing a `currency` getter in the `Money` class and receiving the actual currency information as a constructor parameter.

Our current task list is:

Tasklist:
- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication
- Common `.equals` ✅
- Common `.times`
- Compare Francs with Dollars ✅
- Currency? ✅
- Merge multiplication tests?