### PR TITLE
Pull up "times" operation

### DIFF
--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -1,4 +1,4 @@
-import Money from '../money';
+import Money, { Franc } from '../money';
 
 describe('Money', () => {
   describe('equality', () => {
@@ -8,6 +8,10 @@ describe('Money', () => {
       expect(Money.dollar(5).equals(Money.dollar(5))).toBe(true);
       expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
       expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);
+    });
+
+    it('should return true if comparing two different classes with the same amount and currency', () => {
+      expect(new Money(5, 'CHF').equals(new Franc(5, 'CHF'))).toBe(true);
     });
   });
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -35,7 +35,7 @@ class Money {
 
 export class Dollar extends Money {
   times(multiplier: number): Money {
-    return new Dollar(this.amount * multiplier, 'USD');
+    return new Money(this.amount * multiplier, 'USD');
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -13,7 +13,7 @@ class Money {
 
   equals(obj: Object): boolean {
     const money: Money = obj as Money;
-    return this.amount == money.amount && obj.constructor.name == this.constructor.name;
+    return this.amount == money.amount && money.currency == this.currency;
   }
 
   static dollar(amount: number): Money {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -35,7 +35,7 @@ class Money {
 
 export class Dollar extends Money {
   times(multiplier: number): Money {
-    return new Money(this.amount * multiplier, 'USD');
+    return new Money(this.amount * multiplier, this.currency);
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -41,7 +41,7 @@ export class Dollar extends Money {
 
 export class Franc extends Money {
   times(multiplier: number): Money {
-    return new Franc(this.amount * multiplier, 'CHF');
+    return new Money(this.amount * multiplier, 'CHF');
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -41,7 +41,7 @@ export class Dollar extends Money {
 
 export class Franc extends Money {
   times(multiplier: number): Money {
-    return new Money(this.amount * multiplier, 'CHF');
+    return new Money(this.amount * multiplier, this.currency);
   }
 }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -25,7 +25,7 @@ class Money {
   }
 
   times(multiplier: number): Money {
-    return new Money(0, 'USD');
+    return new Money(this.amount * multiplier, this.currency);
   }
 
   get currency(): string {
@@ -33,16 +33,8 @@ class Money {
   }
 }
 
-export class Dollar extends Money {
-  times(multiplier: number): Money {
-    return new Money(this.amount * multiplier, this.currency);
-  }
-}
+export class Dollar extends Money {}
 
-export class Franc extends Money {
-  times(multiplier: number): Money {
-    return new Money(this.amount * multiplier, this.currency);
-  }
-}
+export class Franc extends Money {}
 
 export default Money;

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,4 +1,4 @@
-abstract class Money {
+class Money {
   private _amount: number;
   private _currency: string;
 
@@ -24,7 +24,9 @@ abstract class Money {
     return new Franc(amount, 'CHF');
   }
 
-  abstract times(multiplier: number): Money;
+  times(multiplier: number): Money {
+    return new Money(0, 'USD');
+  }
 
   get currency(): string {
     return this._currency;

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -33,13 +33,13 @@ abstract class Money {
 
 export class Dollar extends Money {
   times(multiplier: number): Money {
-    return Money.dollar(this.amount * multiplier);
+    return new Dollar(this.amount * multiplier, 'USD');
   }
 }
 
 export class Franc extends Money {
   times(multiplier: number): Money {
-    return Money.franc(this.amount * multiplier);
+    return new Franc(this.amount * multiplier, 'CHF');
   }
 }
 


### PR DESCRIPTION
We had similar implementations between `Dollar.times` and `Franc.times`. This PR pulls up this method to the `Money` class, common ancestry for both `Dollar` and `Franc`. Our current task list is:

- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication
- Common `.equals` ✅
- Common `.times` ✅
- Compare Francs with Dollars ✅
- Currency? ✅
- Merge multiplication tests?