### PR TITLE
Delete franc and dollar classes

### DIFF
--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -9,10 +9,6 @@ describe('Money', () => {
       expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
       expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);
     });
-
-    it('should return true if comparing two different classes with the same amount and currency', () => {
-      expect(new Money(5, 'CHF').equals(new Franc(5, 'CHF'))).toBe(true);
-    });
   });
 
   describe('currency', () => {

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -3,8 +3,6 @@ import Money, { Franc } from '../money';
 describe('Money', () => {
   describe('equality', () => {
     it('should consider an object representing $5 equals to another object representing $5', () => {
-      expect(Money.franc(5).equals(Money.franc(5))).toBe(true);
-      expect(Money.franc(5).equals(Money.franc(6))).toBe(false);
       expect(Money.dollar(5).equals(Money.dollar(5))).toBe(true);
       expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
       expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -1,21 +1,6 @@
 import Money from '../money';
 
 describe('Money', () => {
-  describe('equality', () => {
-    it('should consider an object representing $5 equals to another object representing $5', () => {
-      expect(Money.dollar(5).equals(Money.dollar(5))).toBe(true);
-      expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
-      expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);
-    });
-  });
-
-  describe('currency', () => {
-    expect(Money.dollar(5).currency).toEqual('USD');
-    expect(Money.franc(5).currency).toEqual('CHF');
-  });
-});
-
-describe('Dollar', () => {
   it.todo('should sum $5 + 10CHF as being $10 if exchange rate is 2:1');
 
   describe('multiplication', () => {
@@ -33,22 +18,17 @@ describe('Dollar', () => {
       expect(product.equals(Money.dollar(15))).toBe(true);
     });
   });
-});
 
-describe('Franc', () => {
-  describe('multiplication', () => {
-    it('should multiply $5 by 2 and get $10', () => {
-      const five = Money.franc(5);
-      const product = five.times(2);
-      expect(product.equals(Money.franc(10))).toBe(true);
+  describe('equality', () => {
+    it('should consider an object representing $5 equals to another object representing $5', () => {
+      expect(Money.dollar(5).equals(Money.dollar(5))).toBe(true);
+      expect(Money.dollar(5).equals(Money.dollar(6))).toBe(false);
+      expect(Money.franc(5).equals(Money.dollar(5))).toBe(false);
     });
+  });
 
-    it('should preserve the initial dollar amount when multiplying multiple times', () => {
-      const five = Money.franc(5);
-      let product: Money = five.times(2);
-      expect(product.equals(Money.franc(10))).toBe(true);
-      product = five.times(3);
-      expect(product.equals(Money.franc(15))).toBe(true);
-    });
+  describe('currency', () => {
+    expect(Money.dollar(5).currency).toEqual('USD');
+    expect(Money.franc(5).currency).toEqual('CHF');
   });
 });

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -1,4 +1,4 @@
-import Money, { Franc } from '../money';
+import Money from '../money';
 
 describe('Money', () => {
   describe('equality', () => {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,4 +1,4 @@
-class Money {
+export default class Money {
   private _amount: number;
   private _currency: string;
 
@@ -32,9 +32,3 @@ class Money {
     return this._currency;
   }
 }
-
-export class Dollar extends Money {}
-
-export class Franc extends Money {}
-
-export default Money;

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -21,7 +21,7 @@ class Money {
   }
 
   static franc(amount: number): Money {
-    return new Franc(amount, 'CHF');
+    return new Money(amount, 'CHF');
   }
 
   times(multiplier: number): Money {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -17,7 +17,7 @@ class Money {
   }
 
   static dollar(amount: number): Money {
-    return new Dollar(amount, 'USD');
+    return new Money(amount, 'USD');
   }
 
   static franc(amount: number): Money {


### PR DESCRIPTION
We had two classes, `Dollar` and `Franc`, with empty implementations, both of them subclassing `Money`. This PR removes these two classes and updates the code to use `Money` instances instead.

Tasklist:
- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 * 2 = $10 ✅
- Make "amount" private ✅
- Dollar side-effects? ✅
- Money rounding?
- equals() ✅
- Equal null
- Equal object
- 5 CHF * 2 = 10 CHF ✅
- Dollar/Franc duplication ✅
- Common `.equals` ✅
- Common `.times` ✅
- Compare Francs with Dollars ✅
- Currency? ✅
- Merge multiplication tests? ✅