### PR TITLE
Reduce mixed currency money

### DIFF
--- a/src/bank/index.spec.ts
+++ b/src/bank/index.spec.ts
@@ -13,6 +13,12 @@ describe('Bank', () => {
 
         expect(result).toEqual(Money.dollar(7));
       });
+
+      it('should reduce Money', () => {
+        const bank: Bank = new Bank();
+        const result: Money = bank.reduce(Money.dollar(1), 'USD');
+        expect(result).toEqual(Money.dollar(1));
+      });
     });
   });
 });

--- a/src/bank/index.spec.ts
+++ b/src/bank/index.spec.ts
@@ -3,6 +3,13 @@ import Expression, { Sum } from '../expression';
 import Money from '../money';
 
 describe('Bank', () => {
+  describe('rates', () => {
+    it('should return 1 if currencies are the same', () => {
+      const bank: Bank = new Bank();
+      expect(bank.rate('USD', 'USD')).toEqual(1);
+    });
+  });
+
   describe('reduce', () => {
     describe('sum', () => {
       it('should reduce a sum expression', () => {
@@ -22,6 +29,7 @@ describe('Bank', () => {
 
       it('should reduce mixed Money currencies', () => {
         const bank: Bank = new Bank();
+        bank.addRate('CHF', 'USD', 2);
         const result: Money = bank.reduce(Money.franc(2), 'USD');
         expect(result).toEqual(Money.dollar(1));
       });

--- a/src/bank/index.spec.ts
+++ b/src/bank/index.spec.ts
@@ -19,6 +19,12 @@ describe('Bank', () => {
         const result: Money = bank.reduce(Money.dollar(1), 'USD');
         expect(result).toEqual(Money.dollar(1));
       });
+
+      it('should reduce mixed Money currencies', () => {
+        const bank: Bank = new Bank();
+        const result: Money = bank.reduce(Money.franc(2), 'USD');
+        expect(result).toEqual(Money.dollar(1));
+      });
     });
   });
 });

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -3,6 +3,6 @@ import Expression from '../expression';
 
 export default class Bank {
   reduce(source: Expression, to: string): Money {
-    return source.reduce(to);
+    return source.reduce(this, to);
   }
 }

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -2,11 +2,22 @@ import Money from '../money';
 import Expression from '../expression';
 
 export default class Bank {
+  private _rates: Object;
+
+  constructor() {
+    this._rates = {};
+  }
+
   reduce(source: Expression, to: string): Money {
     return source.reduce(this, to);
   }
 
   rate(from: string, to: string): number {
-    return from == 'CHF' && to == 'USD' ? 2 : 1;
+    if (from === to) return 1;
+    return this._rates[`${from}-${to}`];
+  }
+
+  addRate(from: string, to: string, rate: number): void {
+    this._rates[`${from}-${to}`] = rate;
   }
 }

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -5,4 +5,8 @@ export default class Bank {
   reduce(source: Expression, to: string): Money {
     return source.reduce(this, to);
   }
+
+  rate(from: string, to: string): number {
+    return from == 'CHF' && to == 'USD' ? 2 : 1;
+  }
 }

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -2,8 +2,9 @@ import Money from '../money';
 import Expression, { Sum } from '../expression';
 
 export default class Bank {
-  reduce(to: Expression, currency: string): Money {
-    const sum: Sum = to as Sum;
-    return sum.reduce(currency);
+  reduce(source: Expression, to: string): Money {
+    if (source instanceof Money) return source as Money;
+    const sum: Sum = source as Sum;
+    return sum.reduce(to);
   }
 }

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -1,12 +1,8 @@
 import Money from '../money';
-import Expression, { Sum } from '../expression';
+import Expression from '../expression';
 
 export default class Bank {
   reduce(source: Expression, to: string): Money {
-    if (source instanceof Money) {
-      source.reduce(to);
-    }
-
-    return (source as Sum).reduce(to);
+    return source.reduce(to);
   }
 }

--- a/src/bank/index.ts
+++ b/src/bank/index.ts
@@ -3,8 +3,10 @@ import Expression, { Sum } from '../expression';
 
 export default class Bank {
   reduce(source: Expression, to: string): Money {
-    if (source instanceof Money) return source as Money;
-    const sum: Sum = source as Sum;
-    return sum.reduce(to);
+    if (source instanceof Money) {
+      source.reduce(to);
+    }
+
+    return (source as Sum).reduce(to);
   }
 }

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -1,6 +1,8 @@
 import Money from '../money';
 
-export default interface Expression {}
+export default interface Expression {
+  reduce(to: string): Money;
+}
 
 export class Sum implements Expression {
   private _augend: Money;

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -1,7 +1,8 @@
+import Bank from '../bank';
 import Money from '../money';
 
 export default interface Expression {
-  reduce(to: string): Money;
+  reduce(bank: Bank, to: string): Money;
 }
 
 export class Sum implements Expression {
@@ -21,7 +22,7 @@ export class Sum implements Expression {
     return this._addend;
   }
 
-  reduce(to: string): Money {
+  reduce(bank: Bank, to: string): Money {
     const amount: number = this.augend.amount + this.addend.amount;
     return new Money(amount, to);
   }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,3 +1,4 @@
+import Bank from '../bank';
 import Expression, { Sum } from '../expression';
 
 export default class Money implements Expression {
@@ -34,7 +35,7 @@ export default class Money implements Expression {
     return new Sum(this, addend);
   }
 
-  reduce(to: string): Money {
+  reduce(bank: Bank, to: string): Money {
     const rate: number = this.currency == 'CHF' && to == 'USD' ? 2 : 1;
     return new Money(this.amount / rate, to);
   }

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -1,6 +1,6 @@
 import Expression, { Sum } from '../expression';
 
-export default class Money {
+export default class Money implements Expression {
   private _amount: number;
   private _currency: string;
 
@@ -32,6 +32,10 @@ export default class Money {
 
   plus(addend: Money): Expression {
     return new Sum(this, addend);
+  }
+
+  reduce(to: string): Money {
+    return this;
   }
 
   get currency(): string {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -36,7 +36,7 @@ export default class Money implements Expression {
   }
 
   reduce(bank: Bank, to: string): Money {
-    const rate: number = this.currency == 'CHF' && to == 'USD' ? 2 : 1;
+    const rate: number = bank.rate(this.currency, to);
     return new Money(this.amount / rate, to);
   }
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -35,7 +35,8 @@ export default class Money implements Expression {
   }
 
   reduce(to: string): Money {
-    return this;
+    const rate: number = this.currency == 'CHF' && to == 'USD' ? 2 : 1;
+    return new Money(this.amount / rate, to);
   }
 
   get currency(): string {


### PR DESCRIPTION
Our `Bank` class is already able to reduce `Money` instances with the same currency. This PR expands this implementation to also handle `Money` instances of different currencies.

Task list:
- $5 + 10CHF = $10 if rate is 2:1 🎯
- $5 + $5 = $10 ✅
- Return Money from $5 + $5
- Bank.reduce(Money) ✅
- Reduce Money with conversion ✅
- Reduce(Bank, String) ✅