### PR TITLE
Add support to sum mixed currencies

### DIFF
--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -23,7 +23,8 @@ export class Sum implements Expression {
   }
 
   reduce(bank: Bank, to: string): Money {
-    const amount: number = this.augend.amount + this.addend.amount;
+    const amount: number =
+      this.augend.reduce(bank, to).amount + this.addend.reduce(bank, to).amount;
     return new Money(amount, to);
   }
 }

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -6,19 +6,19 @@ export default interface Expression {
 }
 
 export class Sum implements Expression {
-  private _augend: Money;
-  private _addend: Money;
+  private _augend: Expression;
+  private _addend: Expression;
 
-  constructor(augend: Money, addend: Money) {
+  constructor(augend: Expression, addend: Expression) {
     this._augend = augend;
     this._addend = addend;
   }
 
-  get augend(): Money {
+  get augend(): Expression {
     return this._augend;
   }
 
-  get addend(): Money {
+  get addend(): Expression {
     return this._addend;
   }
 

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -3,6 +3,7 @@ import Money from '../money';
 
 export default interface Expression {
   reduce(bank: Bank, to: string): Money;
+  plus(addend: Expression): Expression;
 }
 
 export class Sum implements Expression {
@@ -26,5 +27,9 @@ export class Sum implements Expression {
     const amount: number =
       this.augend.reduce(bank, to).amount + this.addend.reduce(bank, to).amount;
     return new Money(amount, to);
+  }
+
+  plus(addend: Expression): Expression {
+    throw new Error('Method not implemented.');
   }
 }

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -4,8 +4,8 @@ import Bank from '../bank';
 
 describe('Money', () => {
   it('should sum $5 + 10CHF as being $10 if exchange rate is 2:1', () => {
-    const fiveBucks: Money = Money.dollar(5);
-    const tenFrancs: Money = Money.franc(10);
+    const fiveBucks: Expression = Money.dollar(5);
+    const tenFrancs: Expression = Money.franc(10);
     const bank: Bank = new Bank();
     bank.addRate('CHF', 'USD', 2);
 

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -3,7 +3,16 @@ import Money from '../money';
 import Bank from '../bank';
 
 describe('Money', () => {
-  it.todo('should sum $5 + 10CHF as being $10 if exchange rate is 2:1');
+  it('should sum $5 + 10CHF as being $10 if exchange rate is 2:1', () => {
+    const fiveBucks: Money = Money.dollar(5);
+    const tenFrancs: Money = Money.franc(10);
+    const bank: Bank = new Bank();
+    bank.addRate('CHF', 'USD', 2);
+
+    const result: Money = bank.reduce(fiveBucks.plus(tenFrancs), 'USD');
+
+    expect(result).toEqual(Money.dollar(10));
+  });
 
   describe('addition', () => {
     it('should return a Sum expression', () => {

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -31,7 +31,7 @@ export default class Money implements Expression {
     return new Money(this.amount * multiplier, this.currency);
   }
 
-  plus(addend: Money): Expression {
+  plus(addend: Expression): Expression {
     return new Sum(this, addend);
   }
 


### PR DESCRIPTION
Thanks to our previous work, to implement a multi-currency addition we just need to update the `Sum` class to reduce its members. That's what this PR does. With this, our goal is finally reached!

Task list:
- $5 + 10CHF = $10 if rate is 2:1 🎯 🎉 ✨
- $5 + $5 = $10 ✅
- Return Money from $5 + $5
- `Bank.reduce(Money)` ✅
- Reduce Money with conversion ✅
- `Reduce(Bank, String)` ✅
- `Sum.plus`
- `Expression.times`