### PR TITLE
Add .plus and .times to Expression interface

### DIFF
--- a/src/expression/index.spec.ts
+++ b/src/expression/index.spec.ts
@@ -16,4 +16,18 @@ describe('Sum', () => {
       expect(result).toEqual(Money.dollar(15));
     });
   });
+
+  describe('times', () => {
+    it('should multiply a sum', () => {
+      const fiveBucks: Expression = Money.dollar(5);
+      const tenFrancs: Expression = Money.franc(10);
+      const bank: Bank = new Bank();
+      bank.addRate('CHF', 'USD', 2);
+
+      const sum = new Sum(fiveBucks, tenFrancs).times(2);
+      const result = sum.reduce(bank, 'USD');
+
+      expect(result).toEqual(Money.dollar(20));
+    });
+  });
 });

--- a/src/expression/index.spec.ts
+++ b/src/expression/index.spec.ts
@@ -1,0 +1,19 @@
+import Expression, { Sum } from '.';
+import Bank from '../bank';
+import Money from '../money';
+
+describe('Sum', () => {
+  describe('plus', () => {
+    it('should sum two expressions', () => {
+      const fiveBucks: Expression = Money.dollar(5);
+      const tenFrancs: Expression = Money.franc(10);
+      const bank: Bank = new Bank();
+      bank.addRate('CHF', 'USD', 2);
+
+      const sum = new Sum(fiveBucks, tenFrancs).plus(fiveBucks);
+      const result = sum.reduce(bank, 'USD');
+
+      expect(result).toEqual(Money.dollar(15));
+    });
+  });
+});

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -4,6 +4,7 @@ import Money from '../money';
 export default interface Expression {
   reduce(bank: Bank, to: string): Money;
   plus(addend: Expression): Expression;
+  times(multiplier: number): Expression;
 }
 
 export class Sum implements Expression {
@@ -31,5 +32,9 @@ export class Sum implements Expression {
 
   plus(addend: Expression): Expression {
     return new Sum(this, addend);
+  }
+
+  times(multiplier: number): Expression {
+    return new Sum(this.augend.times(multiplier), this.addend.times(multiplier));
   }
 }

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -30,6 +30,6 @@ export class Sum implements Expression {
   }
 
   plus(addend: Expression): Expression {
-    throw new Error('Method not implemented.');
+    return new Sum(this, addend);
   }
 }

--- a/src/money/index.spec.ts
+++ b/src/money/index.spec.ts
@@ -15,14 +15,15 @@ describe('Money', () => {
   });
 
   describe('addition', () => {
-    it('should return a Sum expression', () => {
-      const five: Money = Money.dollar(5);
+    it('should return a Sum expression if currencies are not equal', () => {
+      const fiveBucks: Money = Money.dollar(5);
+      const fiveFrancs: Money = Money.franc(5);
 
-      const sumExp: Expression = five.plus(five);
+      const sumExp: Expression = fiveBucks.plus(fiveFrancs);
       const sum = sumExp as Sum;
 
-      expect(sum.augend).toEqual(five);
-      expect(sum.addend).toEqual(five);
+      expect(sum.augend).toEqual(fiveBucks);
+      expect(sum.addend).toEqual(fiveFrancs);
     });
 
     it('should sum $5 + $5 and get $10', () => {
@@ -33,6 +34,11 @@ describe('Money', () => {
       const reduced: Money = bank.reduce(sum, 'USD');
 
       expect(reduced).toEqual(Money.dollar(10));
+    });
+
+    it('should return a Money object if the two currencies are the same', () => {
+      const result = Money.dollar(1).plus(Money.dollar(1));
+      expect(result).toBeInstanceOf(Money);
     });
   });
 

--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -32,6 +32,8 @@ export default class Money implements Expression {
   }
 
   plus(addend: Expression): Expression {
+    if (addend instanceof Money && (addend as Money).currency == this.currency)
+      return new Money(this.amount + addend.amount, this.currency);
     return new Sum(this, addend);
   }
 


### PR DESCRIPTION
To make the `Expression` interface compliant to `Money` operations, we need to implement `Sum.plus` (that was mocked in chapter #15) and declare `Expression.times`. This PR does that. With this, we're done with our check list and with this example! 🎉

- $5 + 10CHF = $10 if rate is 2:1 🎯 ✅ 🎉 ✨
- $5 + $5 = $10 ✅
- Return Money from $5 + $5 ✅
- Bank.reduce(Money) ✅
- Reduce Money with conversion ✅
- Reduce(Bank, String) ✅
- Sum.plus ✅
- Expression.times ✅
